### PR TITLE
fix: add build step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build
+        run: pnpm build
+
       - name: Release and Publish
         run: pnpm exec semantic-release
         env:


### PR DESCRIPTION
## Summary
- release workflowで`pnpm build`ステップが抜けていたため、npm publish時に`dist/`ディレクトリが空でpublishが失敗していた問題を修正
- `pnpm install`の後、`semantic-release`の前に`pnpm build`を追加

## Test plan
- [ ] mainにマージ後、CIトリガーでreleaseワークフローが正常に完了することを確認
- [ ] npm publishのtarballに`dist/`が含まれていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)