### PR TITLE
fix: remove leading ./ from bin path

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Markdown preview CLI with live reload",
   "type": "module",
   "bin": {
-    "peek": "./dist/index.js"
+    "peek": "dist/index.js"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Summary
- package.jsonのbinパスから先頭の`./`を削除（`./dist/index.js` → `dist/index.js`）
- npm publish時に`"bin[peek]" script name was cleaned`という警告が出ていた問題を修正

## Test plan
- [ ] npm publishで`bin[peek] script name was cleaned`の警告が出なくなることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)