### PR TITLE
fix: change release workflow trigger from workflow_run to push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,9 @@
 name: Release
 
 on:
-  workflow_run:
-    workflows: [CI]
-    types: [completed]
-    branches: [main]
+  push:
+    branches:
+      - main
 
 jobs:
   release:


### PR DESCRIPTION
## Summary
- releaseワークフローのトリガーを`workflow_run`から`push`(mainブランチ)に変更
- `workflow_run`ではsecretsが正しく渡されず、npm publishで`ENEEDAUTH`エラーが発生していた

## Test plan
- [ ] mainにマージ後、pushトリガーでreleaseワークフローが起動することを確認
- [ ] npm publishが認証エラーなく成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)