### PR TITLE
fix: change CI trigger from push to pull_request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,8 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    branches: [main]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- CI workflowのトリガーを `push` on main から `pull_request` on main に変更
- PRベースでCIが走るようにすることで、マージ前にチェックが通るか確認できるようになる

## Test plan
- [ ] PRを作成してCIが正しくトリガーされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)