### PR TITLE
fix: remove stale workflow_run condition from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
## Summary
- release workflowから不要な `if: ${{ github.event.workflow_run.conclusion == 'success' }}` 条件を削除
- この条件は `workflow_run` トリガー時代の残りもので、現在の `push` トリガーでは不要

## Test plan
- [ ] mainにマージ後、pushトリガーでrelease workflowが正しく実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)