### PR TITLE
chore: update README and CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
 
       - run: pnpm lint
 
+      - run: pnpm format:check
+
       - run: pnpm typecheck
 
       - run: pnpm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,3 +36,4 @@ jobs:
         run: pnpm exec semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Markdown preview CLI with live reload. Spins up a local web server and renders M
 
 - **Live reload** - Automatically refreshes the browser when you save a file
 - **Directory browsing** - Specify a directory to browse and preview Markdown files from a file tree
+- **Syntax highlighting** - Code blocks are highlighted with Shiki
 - **Custom CSS** - Customize styles via `--css` flag or `~/.config/peek/style.css`
 - **Dark / Light theme** - Built-in theme toggle
 
@@ -16,7 +17,7 @@ Markdown preview CLI with live reload. Spins up a local web server and renders M
 ## Install
 
 ```bash
-npm install -g @maku/peek
+npm install -g markdown-peek
 ```
 
 ## Usage
@@ -63,37 +64,6 @@ Custom CSS only affects the `.markdown-body` content area, not the layout chrome
 
 You can override design tokens (CSS custom properties) for full theme customization. See [`docs/design-token-example.css`](docs/design-token-example.css) for reference.
 
-## Development
-
-```bash
-# Install dependencies
-pnpm install
-
-# Start dev server
-pnpm dev
-
-# Run tests
-pnpm test
-
-# Lint and format
-pnpm lint:fix
-pnpm format
-
-# Type check
-pnpm typecheck
-
-# Build for production
-pnpm build
-```
-
-## Tech Stack
-
-- [Hono](https://hono.dev/) - Web framework (routing, JSX SSR)
-- [md4w](https://github.com/nicolo-ribaudo/md4w) - WASM-based Markdown renderer
-- [gunshi](https://github.com/poppinss/gunshi) - CLI framework
-- [TailwindCSS v4](https://tailwindcss.com/) - Styling
-- [@clack/prompts](https://github.com/bombshell-dev/clack) - Terminal UI
-
 ## License
 
-ISC
+MIT


### PR DESCRIPTION
## Summary
- READMEのパッケージ名を `@maku/peek` → `markdown-peek` に修正
- Featuresにsyntax highlightingを追加
- ライセンスを ISC → MIT に修正
- Development / Tech Stack セクションを削除
- CIに `pnpm format:check` ステップを追加
- release workflowにNPM provenance設定を追加

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm format:check` passes
- [x] `pnpm test` passes (155 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)