### PR TITLE
fix: move shebang banner to outputOptions for tsdown compatibility

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -6,5 +6,7 @@ export default defineConfig({
   format: "esm",
   clean: true,
   loader: { ".css": "text" },
-  banner: "#!/usr/bin/env node\n",
+  outputOptions: {
+    banner: "#!/usr/bin/env node",
+  },
 });


### PR DESCRIPTION
## Summary
- `tsdown.config.ts` のトップレベル `banner` オプションが tsdown v0.12 で無視されていたため、ビルド成果物 `dist/index.js` に `#!/usr/bin/env node` shebang が含まれなかった
- shebang がないと `npx peek` 実行時に JS ファイルがシェルスクリプトとして解釈され、`import` 文が ImageMagick の `import` コマンドとして実行されてエラーになっていた
- `banner` を `outputOptions.banner` に移動して修正

## Test plan
- [ ] `pnpm build` を実行し、`dist/index.js` の1行目が `#!/usr/bin/env node` であることを確認
- [ ] `npx peek` でCLIが正常に起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)