### PR TITLE
feat: change code highlight theme to vitesse

### DIFF
--- a/src/markdown/renderer.ts
+++ b/src/markdown/renderer.ts
@@ -14,8 +14,8 @@ export function initMarkdown(): Promise<void> {
       instance.use(
         fromAsyncCodeToHtml(codeToHtml, {
           themes: {
-            light: "gruvbox-light-hard",
-            dark: "gruvbox-dark-hard",
+            light: "vitesse-light",
+            dark: "vitesse-dark",
           },
           defaultColor: false,
         }),


### PR DESCRIPTION
## Summary
- コードハイライトのテーマを `gruvbox-light-hard` / `gruvbox-dark-hard` から `vitesse-light` / `vitesse-dark` に変更

## Test plan
- [ ] マークダウンプレビューでコードブロックが正しくハイライトされること
- [ ] ライト・ダークの両テーマが適用されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)