### PR TITLE
fix: make ExternalLink open standalone file view

### DIFF
--- a/src/pages/directory-view.tsx
+++ b/src/pages/directory-view.tsx
@@ -32,7 +32,7 @@ export function DirectoryViewPage({
         id="header-bar"
         breadcrumbs={[{ label: dirTitle, href: "/" }, { label: fileTitle }]}
         showSidebarToggle
-        externalLinkHref={`/view?path=${encodeURIComponent(currentPath)}`}
+        externalLinkHref={`/${currentPath}`}
       />
 
       <MainContent class="px-5 sm:px-10 py-5 sm:py-10">

--- a/src/pages/file-preview.tsx
+++ b/src/pages/file-preview.tsx
@@ -1,6 +1,4 @@
-import { MainContent } from "../components/layout/main-content.js";
 import { MarkdownContent } from "../components/layout/markdown-content.js";
-import { PageHeader } from "../components/layout/page-header.js";
 import type { ResolvedStyles } from "../config/styles.js";
 import { Document } from "../renderer/document.js";
 
@@ -17,13 +15,11 @@ export function FilePreviewPage({
 }: FilePreviewPageProps) {
   return (
     <Document title={title} styles={styles} mode="file">
-      <PageHeader breadcrumbs={[{ label: title }]} />
-
-      <MainContent class="px-2 sm:px-5 py-5 sm:py-15">
+      <main class="px-2 sm:px-5 py-5 sm:py-15">
         <div class="max-w-4xl mx-auto">
           <MarkdownContent htmlContent={htmlContent} />
         </div>
-      </MainContent>
+      </main>
     </Document>
   );
 }


### PR DESCRIPTION
## Summary
- ExternalLink の href を `/view?path=...`（サイドバー付きビュー）から `/:path`（単独ビュー）に変更
- FilePreviewPage から `MainContent`（`id="main-content"` によりサイドバーのマージンが適用される）を削除し、plain な `<main>` に置き換え
- 不要な `PageHeader` も削除

## Test plan
- [ ] directory モードでサーバー起動し、`/view?path=...` のサイドバー付きビューが正常に動作すること
- [ ] ExternalLink をクリックして単独ビュー（`/:path`）が新しいタブで開くこと
- [ ] 単独ビューに左側のサイドバー余白がないこと
- [ ] `pnpm test` が全てパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)