### PR TITLE
fix: remove iframe sandbox attribute

### DIFF
--- a/src/components/content-view.tsx
+++ b/src/components/content-view.tsx
@@ -1,8 +1,5 @@
 import type { ContentType } from "../core/content-type.js";
-import {
-  FULLSCREEN_IFRAME_STYLE,
-  IFRAME_SANDBOX,
-} from "../core/iframe-style.js";
+import { FULLSCREEN_IFRAME_STYLE } from "../core/iframe-style.js";
 import { MainContent } from "./layout/main-content.js";
 import { MarkdownContent } from "./layout/markdown-content.js";
 
@@ -31,7 +28,6 @@ export function ContentView({
           title={fileTitle}
           src={rawUrl}
           style={FULLSCREEN_IFRAME_STYLE}
-          sandbox={IFRAME_SANDBOX}
         />
       </MainContent>
     );

--- a/src/core/iframe-style.ts
+++ b/src/core/iframe-style.ts
@@ -6,6 +6,3 @@ export const FULLSCREEN_IFRAME_STYLE = {
   top: "0",
   left: "0",
 } as const;
-
-export const IFRAME_SANDBOX =
-  "allow-scripts allow-same-origin allow-forms allow-popups allow-modals" as const;

--- a/src/server/renderer/html-document.test.ts
+++ b/src/server/renderer/html-document.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { IFRAME_SANDBOX } from "../../core/iframe-style.js";
 import {
   SSE_INITIAL_RETRY_MS,
   SSE_MAX_RETRIES,
@@ -14,11 +13,10 @@ describe("renderHtmlDocument", () => {
     expect(html).toContain("<title>My Page - peek</title>");
   });
 
-  it("renders iframe with correct src, id, and sandbox attributes", () => {
+  it("renders iframe with correct src and id attributes", () => {
     const html = renderHtmlDocument("test", "/api/raw?file=hello.html");
     expect(html).toContain('src="/api/raw?file=hello.html"');
     expect(html).toContain('id="content-frame"');
-    expect(html).toContain(`sandbox="${IFRAME_SANDBOX}"`);
   });
 
   it("escapes special characters in title", () => {

--- a/src/server/renderer/html-document.tsx
+++ b/src/server/renderer/html-document.tsx
@@ -1,5 +1,4 @@
 import renderToString from "preact-render-to-string";
-import { IFRAME_SANDBOX } from "../../core/iframe-style.js";
 import {
   SSE_INITIAL_RETRY_MS,
   SSE_MAX_RETRIES,
@@ -60,12 +59,7 @@ export function HtmlDocument({ title, rawContentUrl }: HtmlDocumentProps) {
         />
       </head>
       <body>
-        <iframe
-          id="content-frame"
-          title={title}
-          src={rawContentUrl}
-          sandbox={IFRAME_SANDBOX}
-        />
+        <iframe id="content-frame" title={title} src={rawContentUrl} />
         <script dangerouslySetInnerHTML={{ __html: sseReloadScript }} />
       </body>
     </html>

--- a/src/server/routes/api.tsx
+++ b/src/server/routes/api.tsx
@@ -3,10 +3,7 @@ import { Hono } from "hono";
 import renderToString from "preact-render-to-string";
 import type { ContentType } from "../../core/content-type.js";
 import { getContentType } from "../../core/content-type.js";
-import {
-  FULLSCREEN_IFRAME_STYLE,
-  IFRAME_SANDBOX,
-} from "../../core/iframe-style.js";
+import { FULLSCREEN_IFRAME_STYLE } from "../../core/iframe-style.js";
 import { isWithinBase } from "../../core/path.js";
 import type { FileTreeCache } from "../../lib/file-tree-cache.js";
 import { logger } from "../../lib/logger.js";
@@ -28,12 +25,7 @@ export type ApiConfig = FileApiConfig | DirectoryApiConfig;
 
 function renderRawHtmlIframe(rawUrl: string, title: string): string {
   return renderToString(
-    <iframe
-      src={rawUrl}
-      style={FULLSCREEN_IFRAME_STYLE}
-      title={title}
-      sandbox={IFRAME_SANDBOX}
-    />,
+    <iframe src={rawUrl} style={FULLSCREEN_IFRAME_STYLE} title={title} />,
   );
 }
 
@@ -129,8 +121,7 @@ export function createApiRoutes(config: ApiConfig): Hono {
         return c.text("Failed to read file", 500);
       }
       // CSP is intentionally omitted: this is a local preview tool serving
-      // the user's own HTML files. The iframe sandbox attribute provides
-      // sufficient isolation while allowing full HTML expressiveness.
+      // the user's own HTML files with full HTML expressiveness.
       c.header("X-Content-Type-Options", "nosniff");
       return c.html(result.value);
     }

--- a/src/server/routes/html-file.test.ts
+++ b/src/server/routes/html-file.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { IFRAME_SANDBOX } from "../../core/iframe-style.js";
 import { createHtmlFileRoutes } from "./html-file.js";
 
 describe("html file routes", () => {
@@ -13,7 +12,7 @@ describe("html file routes", () => {
     expect(html).toContain("test.html - peek");
     expect(html).toContain("<iframe");
     expect(html).toContain("/api/raw");
-    expect(html).toContain(`sandbox="${IFRAME_SANDBOX}"`);
+    expect(html).not.toContain("sandbox=");
   });
 
   it("GET / includes SSE reload script", async () => {


### PR DESCRIPTION
## Summary

- Remove `IFRAME_SANDBOX` constant and all `sandbox` attributes from iframes
- The `allow-scripts + allow-same-origin` combination allowed scripts to remove the sandbox itself, making protection ineffective
- As a local preview tool serving user's own files, the sandbox was misleading rather than protective

Closes #38

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (208 tests, all green)
- [ ] Manual: preview an HTML file and confirm it renders correctly without sandbox restrictions

🤖 Generated with [Claude Code](https://claude.com/claude-code)