### PR TITLE
fix: remove hardcoded dotfile exclusion and framework-specific ignore patterns

### DIFF
--- a/src/lib/file-tree.test.ts
+++ b/src/lib/file-tree.test.ts
@@ -43,13 +43,12 @@ describe("buildFileTree", () => {
     expect(files.some((f) => f.name === "README.md")).toBe(true);
   });
 
-  it("excludes .git and node_modules", async () => {
+  it("excludes .git", async () => {
     const result = await buildFileTree(testDir);
     const tree = assertOk(result);
     const allNames = flattenNames(tree);
 
     expect(allNames).not.toContain(".git");
-    expect(allNames).not.toContain("node_modules");
   });
 
   it("only includes supported files (.md, .html, .htm)", async () => {
@@ -75,11 +74,11 @@ describe("buildFileTree", () => {
     }
   });
 
-  it("excludes dotfiles", async () => {
+  it("includes dotfiles not excluded by ignore rules", async () => {
     const result = await buildFileTree(testDir);
     const tree = assertOk(result);
     const allNames = flattenNames(tree);
-    expect(allNames).not.toContain(".hidden.md");
+    expect(allNames).toContain(".hidden.md");
   });
 
   it("excludes empty directories", async () => {

--- a/src/lib/file-tree.ts
+++ b/src/lib/file-tree.ts
@@ -10,16 +10,7 @@ import { err, ok } from "../core/result.js";
 import { logger } from "./logger.js";
 import { readTextFile } from "./read-text-file.js";
 
-const DEFAULT_IGNORE_PATTERNS = [
-  ".git/",
-  "node_modules/",
-  ".next/",
-  ".nuxt/",
-  ".svelte-kit/",
-  "dist/",
-  "build/",
-  ".cache/",
-];
+const DEFAULT_IGNORE_PATTERNS = [".git/"];
 
 type IgnoreRule = {
   readonly ig: Ignore;
@@ -162,8 +153,6 @@ async function processEntries(
   const dirPromises: Promise<FileTreeNode | null>[] = [];
 
   for (const entry of entries) {
-    if (entry.name.startsWith(".")) continue;
-
     const fullPath = join(dir, entry.name);
     const relPath = relative(rootDir, fullPath);
 


### PR DESCRIPTION
## Summary
- ドットファイルの一律非表示(`startsWith(".")`)を削除し、`.gitignore` によるフィルタリングに委譲
- フレームワーク固有のデフォルト除外パターン(`.next/`, `.nuxt/`, `.svelte-kit/`, `node_modules/`, `dist/`, `build/`, `.cache/`)を削除
- `.git/` のみデフォルト除外パターンとして維持

## Test plan
- [x] 既存テスト全208件パス
- [x] ドットファイル(`.hidden.md`)が表示されることを確認するテストに更新
- [x] `.git` の除外テストが引き続きパスすることを確認
- [x] typecheck, lint, format すべてクリア

🤖 Generated with [Claude Code](https://claude.com/claude-code)