### PR TITLE
Rename package from markdown-peek to peeks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# markdown-peek
+# peeks
 
 Markdown and HTML preview CLI with live reload. Spins up a local web server and renders Markdown and HTML files in the browser with real-time updates via Server-Sent Events.
 
@@ -18,7 +18,7 @@ Markdown and HTML preview CLI with live reload. Spins up a local web server and 
 ## Install
 
 ```bash
-npm install -g markdown-peek
+npm install -g peeks
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "markdown-peek",
+  "name": "peeks",
   "version": "1.6.3",
-  "description": "Markdown preview CLI with live reload",
+  "description": "Markdown and HTML preview CLI with live reload",
   "type": "module",
   "bin": {
     "peek": "dist/index.mjs"
@@ -30,6 +30,7 @@
   },
   "keywords": [
     "markdown",
+    "html",
     "preview",
     "cli",
     "live-reload"
@@ -37,7 +38,7 @@
   "author": "Hikaru Otabe",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tuanemuy/markdown-peek.git"
+    "url": "git+https://github.com/tuanemuy/peeks.git"
   },
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
## Summary
- Rename npm package from `markdown-peek` to `peeks` (HTML対応でmarkdown限定じゃなくなったため)
- Update description to mention both Markdown and HTML
- Add `html` to keywords
- Update repository URL
- CLI command `peek` is unchanged

## Migration
After publishing:
```bash
npm deprecate markdown-peek "Renamed to peeks. Install with: npm install -g peeks"
```

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `npm install -g peeks` works after publish
- [ ] `peek` command still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)