### PR TITLE
Rename package to @makuja/peek

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# peeks
+# @makuja/peek
 
 Markdown and HTML preview CLI with live reload. Spins up a local web server and renders Markdown and HTML files in the browser with real-time updates via Server-Sent Events.
 
@@ -18,7 +18,7 @@ Markdown and HTML preview CLI with live reload. Spins up a local web server and 
 ## Install
 
 ```bash
-npm install -g peeks
+npm install -g @makuja/peek
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "peeks",
+  "name": "@makuja/peek",
   "version": "1.6.3",
   "description": "Markdown and HTML preview CLI with live reload",
   "type": "module",
@@ -39,6 +39,9 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tuanemuy/peeks.git"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
## Summary
- Rename npm package from `peeks` to `@makuja/peek`（npmでスコープなし `peeks` が登録ブロックされたため）
- Add `publishConfig.access: public` for scoped package publish
- Update README install command

## Migration
最初の publish 後:
```bash
npm deprecate markdown-peek "Renamed to @makuja/peek. Install with: npm install -g @makuja/peek"
```

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `npm publish --access public` succeeds
- [ ] `npm install -g @makuja/peek` works
- [ ] `peek` command still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)