### PR TITLE
Fix repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "author": "Hikaru Otabe",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tuanemuy/peeks.git"
+    "url": "git+https://github.com/tuanemuy/peek.git"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- Fix repository URL: `peeks.git` → `peek.git`（リポジトリ名変更の反映漏れ）

## Test plan
- [ ] `npm view @makuja/peek` shows correct repository URL after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)