### PR TITLE
feat: persist file tree collapse state in localStorage (#89)

### DIFF
--- a/src/client/directory-app.tsx
+++ b/src/client/directory-app.tsx
@@ -5,12 +5,14 @@ import { Sidebar } from "../components/navigation/sidebar.js";
 import type { ContentType } from "../core/content-type.js";
 import { getContentType } from "../core/content-type.js";
 import type { FileTreeNode } from "../core/file-tree.js";
+import { useFileTreeState } from "./hooks/use-file-tree-state.js";
 import { useNavigation } from "./hooks/use-navigation.js";
 import { useSidebar } from "./hooks/use-sidebar.js";
 import { useSseUpdates } from "./hooks/use-sse-updates.js";
 import { getFileNameFromPath } from "./lib/path-utils.js";
 
 type DirectoryAppProps = {
+  readonly projectId: string;
   readonly dirTitle: string;
   readonly currentPath: string;
   readonly contentType: ContentType;
@@ -19,6 +21,7 @@ type DirectoryAppProps = {
 };
 
 export function DirectoryApp({
+  projectId,
   dirTitle,
   currentPath: initialPath,
   contentType: initialContentType,
@@ -36,6 +39,7 @@ export function DirectoryApp({
   currentPathRef.current = currentPath;
 
   const sidebar = useSidebar();
+  const fileTree = useFileTreeState(projectId);
 
   useNavigation((path, html) => {
     const ct = getContentType(path);
@@ -69,6 +73,8 @@ export function DirectoryApp({
         tree={tree}
         currentPath={currentPath}
         onClose={sidebar.close}
+        isOpen={fileTree.isOpen}
+        onToggle={fileTree.toggle}
       />
 
       <PageHeader

--- a/src/client/hooks/use-file-tree-state.ts
+++ b/src/client/hooks/use-file-tree-state.ts
@@ -1,0 +1,89 @@
+import { useCallback, useLayoutEffect, useRef, useState } from "preact/hooks";
+import {
+  FILE_TREE_STATE_KEY,
+  type FileTreeStateStore,
+  getCollapsedSet,
+  parseStore,
+  purgeExpired,
+  serializeStore,
+  TTL_MS,
+  writeCollapsed,
+} from "../lib/file-tree-state.js";
+
+export type FileTreeState = {
+  readonly isOpen: (path: string) => boolean;
+  readonly toggle: (path: string) => void;
+};
+
+export function useFileTreeState(projectId: string): FileTreeState {
+  // Always start from an empty collapsed set so that the initial client render
+  // matches the SSR markup (all directories expanded). Restoration happens in
+  // useLayoutEffect, after mount.
+  const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set());
+  const initialMount = useRef(true);
+
+  // Read the persisted store, guarding against environments where localStorage
+  // throws (e.g. private browsing).
+  function readStore(): FileTreeStateStore {
+    try {
+      return parseStore(localStorage.getItem(FILE_TREE_STATE_KEY));
+    } catch {
+      return {};
+    }
+  }
+
+  function writeStore(store: FileTreeStateStore): void {
+    try {
+      localStorage.setItem(FILE_TREE_STATE_KEY, serializeStore(store));
+    } catch {
+      // Persistence failures are non-fatal; the in-memory state still drives UI.
+    }
+  }
+
+  // Client-only: useLayoutEffect is safe because this hook is only called from
+  // DirectoryApp, which runs exclusively via hydrate() on the client.
+  // preact-render-to-string does not execute effects during SSR.
+  useLayoutEffect(() => {
+    if (!initialMount.current) return;
+    initialMount.current = false;
+
+    const now = Date.now();
+    const purged = purgeExpired(readStore(), now, TTL_MS);
+    // Touch the current project's entry (keep its existing collapsed set) so
+    // that lastAccess is refreshed, then persist the purge result.
+    const touched = writeCollapsed(
+      purged,
+      projectId,
+      getCollapsedSet(purged, projectId),
+      now,
+    );
+    writeStore(touched);
+    setCollapsed(getCollapsedSet(touched, projectId));
+  }, [projectId]);
+
+  const toggle = useCallback(
+    (path: string) => {
+      setCollapsed((prev) => {
+        const next = new Set(prev);
+        if (next.has(path)) {
+          next.delete(path);
+        } else {
+          next.add(path);
+        }
+        // Re-read the latest store before writing so concurrent updates from
+        // other tabs/projects are not clobbered.
+        const store = writeCollapsed(readStore(), projectId, next, Date.now());
+        writeStore(store);
+        return next;
+      });
+    },
+    [projectId],
+  );
+
+  const isOpen = useCallback(
+    (path: string) => !collapsed.has(path),
+    [collapsed],
+  );
+
+  return { isOpen, toggle };
+}

--- a/src/client/hooks/use-file-tree-state.ts
+++ b/src/client/hooks/use-file-tree-state.ts
@@ -22,6 +22,12 @@ export function useFileTreeState(projectId: string): FileTreeState {
   const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set());
   const initialMount = useRef(true);
 
+  // Keep a ref in sync with the latest collapsed set (same approach as
+  // DirectoryApp's currentPathRef) so that `toggle` can compute the next set
+  // outside of a state updater, keeping the updater pure.
+  const collapsedRef = useRef(collapsed);
+  collapsedRef.current = collapsed;
+
   // Read the persisted store, guarding against environments where localStorage
   // throws (e.g. private browsing).
   function readStore(): FileTreeStateStore {
@@ -63,19 +69,19 @@ export function useFileTreeState(projectId: string): FileTreeState {
 
   const toggle = useCallback(
     (path: string) => {
-      setCollapsed((prev) => {
-        const next = new Set(prev);
-        if (next.has(path)) {
-          next.delete(path);
-        } else {
-          next.add(path);
-        }
-        // Re-read the latest store before writing so concurrent updates from
-        // other tabs/projects are not clobbered.
-        const store = writeCollapsed(readStore(), projectId, next, Date.now());
-        writeStore(store);
-        return next;
-      });
+      const next = new Set(collapsedRef.current);
+      if (next.has(path)) {
+        next.delete(path);
+      } else {
+        next.add(path);
+      }
+      collapsedRef.current = next;
+      // The state updater is kept pure (just returns `next`); the localStorage
+      // side effect runs outside of it. Re-read the latest store before writing
+      // so concurrent updates from other tabs/projects are not clobbered.
+      setCollapsed(next);
+      const store = writeCollapsed(readStore(), projectId, next, Date.now());
+      writeStore(store);
     },
     [projectId],
   );

--- a/src/client/lib/file-tree-state.test.ts
+++ b/src/client/lib/file-tree-state.test.ts
@@ -29,6 +29,38 @@ describe("parseStore", () => {
     };
     expect(parseStore(JSON.stringify(store))).toEqual(store);
   });
+
+  it("returns an empty store for null JSON", () => {
+    expect(parseStore("null")).toEqual({});
+  });
+
+  it("drops entries whose collapsed is not an array", () => {
+    expect(parseStore('{"p":{"collapsed":"x","lastAccess":1}}')).toEqual({});
+  });
+
+  it("drops entries whose lastAccess is not a number", () => {
+    expect(parseStore('{"p":{"collapsed":[],"lastAccess":"old"}}')).toEqual({});
+  });
+
+  it("drops entries that are not objects", () => {
+    expect(parseStore('{"p":42}')).toEqual({});
+  });
+
+  it("excludes non-string elements from collapsed", () => {
+    expect(
+      parseStore('{"p":{"collapsed":["a",1,null,"b"],"lastAccess":5}}'),
+    ).toEqual({ p: { collapsed: ["a", "b"], lastAccess: 5 } });
+  });
+
+  it("keeps valid entries while dropping invalid ones", () => {
+    const raw = JSON.stringify({
+      good: { collapsed: ["a"], lastAccess: 10 },
+      bad: { collapsed: "x", lastAccess: 20 },
+    });
+    expect(parseStore(raw)).toEqual({
+      good: { collapsed: ["a"], lastAccess: 10 },
+    });
+  });
 });
 
 describe("purgeExpired", () => {

--- a/src/client/lib/file-tree-state.test.ts
+++ b/src/client/lib/file-tree-state.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+  type FileTreeStateStore,
+  getCollapsedSet,
+  parseStore,
+  purgeExpired,
+  serializeStore,
+  TTL_MS,
+  writeCollapsed,
+} from "./file-tree-state.js";
+
+describe("parseStore", () => {
+  it("returns an empty store for null", () => {
+    expect(parseStore(null)).toEqual({});
+  });
+
+  it("returns an empty store for invalid JSON", () => {
+    expect(parseStore("{not json")).toEqual({});
+  });
+
+  it("returns an empty store for non-object JSON", () => {
+    expect(parseStore("[]")).toEqual({});
+    expect(parseStore("42")).toEqual({});
+  });
+
+  it("parses a valid store", () => {
+    const store: FileTreeStateStore = {
+      abc: { collapsed: ["a/b"], lastAccess: 123 },
+    };
+    expect(parseStore(JSON.stringify(store))).toEqual(store);
+  });
+});
+
+describe("purgeExpired", () => {
+  const now = 1_000_000_000_000;
+
+  it("removes entries older than the TTL", () => {
+    const store: FileTreeStateStore = {
+      fresh: { collapsed: [], lastAccess: now },
+      stale: { collapsed: ["x"], lastAccess: now - TTL_MS - 1 },
+    };
+    expect(purgeExpired(store, now, TTL_MS)).toEqual({
+      fresh: { collapsed: [], lastAccess: now },
+    });
+  });
+
+  it("keeps entries exactly at the TTL boundary", () => {
+    const store: FileTreeStateStore = {
+      boundary: { collapsed: [], lastAccess: now - TTL_MS },
+    };
+    expect(purgeExpired(store, now, TTL_MS)).toEqual(store);
+  });
+
+  it("does not mutate the input", () => {
+    const store: FileTreeStateStore = {
+      stale: { collapsed: [], lastAccess: now - TTL_MS - 1 },
+    };
+    purgeExpired(store, now, TTL_MS);
+    expect(store.stale).toBeDefined();
+  });
+});
+
+describe("getCollapsedSet", () => {
+  it("returns an empty set when the project is absent", () => {
+    expect(getCollapsedSet({}, "missing")).toEqual(new Set());
+  });
+
+  it("returns the collapsed paths as a set", () => {
+    const store: FileTreeStateStore = {
+      p: { collapsed: ["a", "b"], lastAccess: 0 },
+    };
+    expect(getCollapsedSet(store, "p")).toEqual(new Set(["a", "b"]));
+  });
+});
+
+describe("writeCollapsed", () => {
+  it("updates collapsed and lastAccess for the project", () => {
+    const next = writeCollapsed({}, "p", new Set(["a"]), 100);
+    expect(next.p).toEqual({ collapsed: ["a"], lastAccess: 100 });
+  });
+
+  it("keeps the entry when the collapsed set is empty", () => {
+    const next = writeCollapsed({}, "p", new Set(), 100);
+    expect(next.p).toEqual({ collapsed: [], lastAccess: 100 });
+  });
+
+  it("does not affect other projects", () => {
+    const store: FileTreeStateStore = {
+      other: { collapsed: ["x"], lastAccess: 1 },
+    };
+    const next = writeCollapsed(store, "p", new Set(["a"]), 100);
+    expect(next.other).toEqual({ collapsed: ["x"], lastAccess: 1 });
+  });
+
+  it("does not mutate the input store", () => {
+    const store: FileTreeStateStore = {
+      p: { collapsed: [], lastAccess: 1 },
+    };
+    writeCollapsed(store, "p", new Set(["a"]), 100);
+    expect(store.p).toEqual({ collapsed: [], lastAccess: 1 });
+  });
+});
+
+describe("serializeStore", () => {
+  it("round-trips through parseStore", () => {
+    const store: FileTreeStateStore = {
+      p: { collapsed: ["a/b", "c"], lastAccess: 42 },
+    };
+    expect(parseStore(serializeStore(store))).toEqual(store);
+  });
+});

--- a/src/client/lib/file-tree-state.ts
+++ b/src/client/lib/file-tree-state.ts
@@ -12,15 +12,40 @@ export type FileTreeStateStore = Record<string, ProjectEntry>;
 /**
  * Parse the raw localStorage value into a store. Returns an empty store when
  * the value is absent or not valid JSON (defensive against corruption).
+ *
+ * Each entry is validated structurally: only entries that are objects with a
+ * numeric `lastAccess` and an array `collapsed` are kept. Non-string elements
+ * within `collapsed` are dropped. Invalid entries are skipped entirely so that
+ * downstream functions (purgeExpired, getCollapsedSet) never see malformed data.
  */
 export function parseStore(raw: string | null): FileTreeStateStore {
   if (!raw) return {};
   try {
     const parsed = JSON.parse(raw);
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      return parsed as FileTreeStateStore;
+    // Reject null (typeof null === "object"), arrays, and primitives.
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
     }
-    return {};
+    const store: FileTreeStateStore = {};
+    for (const [projectId, entry] of Object.entries(
+      parsed as Record<string, unknown>,
+    )) {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        continue;
+      }
+      const { collapsed, lastAccess } = entry as {
+        collapsed?: unknown;
+        lastAccess?: unknown;
+      };
+      if (typeof lastAccess !== "number" || !Array.isArray(collapsed)) {
+        continue;
+      }
+      store[projectId] = {
+        collapsed: collapsed.filter((p): p is string => typeof p === "string"),
+        lastAccess,
+      };
+    }
+    return store;
   } catch {
     return {};
   }

--- a/src/client/lib/file-tree-state.ts
+++ b/src/client/lib/file-tree-state.ts
@@ -1,0 +1,79 @@
+export const FILE_TREE_STATE_KEY = "file-tree-state";
+export const TTL_DAYS = 30;
+export const TTL_MS = TTL_DAYS * 24 * 60 * 60 * 1000;
+
+export type ProjectEntry = {
+  readonly collapsed: readonly string[];
+  readonly lastAccess: number;
+};
+
+export type FileTreeStateStore = Record<string, ProjectEntry>;
+
+/**
+ * Parse the raw localStorage value into a store. Returns an empty store when
+ * the value is absent or not valid JSON (defensive against corruption).
+ */
+export function parseStore(raw: string | null): FileTreeStateStore {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as FileTreeStateStore;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Remove entries whose last access is older than `ttlMs`. Pure: returns a new
+ * store without mutating the input.
+ */
+export function purgeExpired(
+  store: FileTreeStateStore,
+  now: number,
+  ttlMs: number,
+): FileTreeStateStore {
+  const next: FileTreeStateStore = {};
+  for (const [projectId, entry] of Object.entries(store)) {
+    if (now - entry.lastAccess <= ttlMs) {
+      next[projectId] = entry;
+    }
+  }
+  return next;
+}
+
+/**
+ * Build the set of collapsed paths for a project (empty set when absent).
+ */
+export function getCollapsedSet(
+  store: FileTreeStateStore,
+  projectId: string,
+): Set<string> {
+  return new Set(store[projectId]?.collapsed ?? []);
+}
+
+/**
+ * Return a new store with the given project's collapsed set and lastAccess
+ * updated. The entry is kept even when the collapsed set is empty so that
+ * lastAccess (TTL) tracking is preserved.
+ */
+export function writeCollapsed(
+  store: FileTreeStateStore,
+  projectId: string,
+  collapsed: Set<string>,
+  now: number,
+): FileTreeStateStore {
+  return {
+    ...store,
+    [projectId]: {
+      collapsed: Array.from(collapsed),
+      lastAccess: now,
+    },
+  };
+}
+
+export function serializeStore(store: FileTreeStateStore): string {
+  return JSON.stringify(store);
+}

--- a/src/components/navigation/file-tree-items.tsx
+++ b/src/components/navigation/file-tree-items.tsx
@@ -1,4 +1,3 @@
-import { useState } from "preact/hooks";
 import type { FileTreeNode } from "../../core/file-tree.js";
 import { ChevronDownIcon, FileIcon, FolderIcon } from "../icons/index.js";
 
@@ -8,25 +7,31 @@ type FileTreeItemsProps = {
   readonly nodes: readonly FileTreeNode[];
   readonly currentPath?: string;
   readonly depth?: number;
+  readonly isOpen?: (path: string) => boolean;
+  readonly onToggle?: (path: string) => void;
 };
 
 function DirectoryItem({
   node,
   currentPath,
   depth,
+  isOpen,
+  onToggle,
 }: {
   readonly node: FileTreeNode;
   readonly currentPath?: string;
   readonly depth: number;
+  readonly isOpen?: (path: string) => boolean;
+  readonly onToggle?: (path: string) => void;
 }) {
-  const [open, setOpen] = useState(true);
+  const open = isOpen ? isOpen(node.path) : true;
 
   return (
     <li class={depth === 0 ? "px-2 lg:px-5" : ""}>
       <button
         type="button"
         aria-expanded={open}
-        onClick={() => setOpen((prev) => !prev)}
+        onClick={() => onToggle?.(node.path)}
         class="flex items-center gap-x-3 w-full py-2 px-3 text-left text-sm text-sidebar-foreground hover:bg-sidebar-accent rounded-lg overflow-hidden"
       >
         <FolderIcon class="shrink-0 size-4" />
@@ -42,6 +47,8 @@ function DirectoryItem({
               nodes={node.children}
               currentPath={currentPath}
               depth={depth + 1}
+              isOpen={isOpen}
+              onToggle={onToggle}
             />
           ) : null}
         </ul>
@@ -54,6 +61,8 @@ export function FileTreeItems({
   nodes,
   currentPath,
   depth = 0,
+  isOpen,
+  onToggle,
 }: FileTreeItemsProps) {
   return (
     <>
@@ -65,6 +74,8 @@ export function FileTreeItems({
               node={node}
               currentPath={currentPath}
               depth={depth}
+              isOpen={isOpen}
+              onToggle={onToggle}
             />
           );
         }

--- a/src/components/navigation/file-tree.tsx
+++ b/src/components/navigation/file-tree.tsx
@@ -4,12 +4,24 @@ import { FileTreeItems } from "./file-tree-items.js";
 type FileTreeProps = {
   readonly nodes: readonly FileTreeNode[];
   readonly currentPath?: string;
+  readonly isOpen?: (path: string) => boolean;
+  readonly onToggle?: (path: string) => void;
 };
 
-export function FileTree({ nodes, currentPath }: FileTreeProps) {
+export function FileTree({
+  nodes,
+  currentPath,
+  isOpen,
+  onToggle,
+}: FileTreeProps) {
   return (
     <ul id="file-tree" class="flex flex-col gap-y-1">
-      <FileTreeItems nodes={nodes} currentPath={currentPath} />
+      <FileTreeItems
+        nodes={nodes}
+        currentPath={currentPath}
+        isOpen={isOpen}
+        onToggle={onToggle}
+      />
     </ul>
   );
 }

--- a/src/components/navigation/sidebar.tsx
+++ b/src/components/navigation/sidebar.tsx
@@ -6,9 +6,18 @@ type SidebarProps = {
   readonly tree: readonly FileTreeNode[];
   readonly currentPath: string;
   readonly onClose?: () => void;
+  readonly isOpen?: (path: string) => boolean;
+  readonly onToggle?: (path: string) => void;
 };
 
-export function Sidebar({ title, tree, currentPath, onClose }: SidebarProps) {
+export function Sidebar({
+  title,
+  tree,
+  currentPath,
+  onClose,
+  isOpen,
+  onToggle,
+}: SidebarProps) {
   return (
     <>
       {/* Overlay for mobile sidebar — visibility driven by body[data-sidebar-open] via CSS */}
@@ -37,7 +46,12 @@ export function Sidebar({ title, tree, currentPath, onClose }: SidebarProps) {
 
           <div class="mt-1.5 h-full overflow-x-hidden overflow-y-auto [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded-none [&::-webkit-scrollbar-track]:bg-scrollbar-track [&::-webkit-scrollbar-thumb]:bg-scrollbar-thumb">
             <nav class="pb-3 w-full flex flex-col">
-              <FileTree nodes={tree} currentPath={currentPath} />
+              <FileTree
+                nodes={tree}
+                currentPath={currentPath}
+                isOpen={isOpen}
+                onToggle={onToggle}
+              />
             </nav>
           </div>
         </div>

--- a/src/core/initial-state.ts
+++ b/src/core/initial-state.ts
@@ -3,6 +3,7 @@ import type { FileTreeNode } from "./file-tree.js";
 
 export type DirectoryInitialState = {
   readonly mode: "directory";
+  readonly projectId: string;
   readonly dirTitle: string;
   readonly currentPath: string;
   readonly contentType: ContentType;

--- a/src/lib/project-id.test.ts
+++ b/src/lib/project-id.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { createProjectId } from "./project-id.js";
+
+describe("createProjectId", () => {
+  it("is deterministic for the same path", () => {
+    expect(createProjectId("/foo/bar")).toBe(createProjectId("/foo/bar"));
+  });
+
+  it("returns a 16-character hex string", () => {
+    const id = createProjectId("/foo/bar");
+    expect(id).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("returns different values for different paths", () => {
+    expect(createProjectId("/foo/bar")).not.toBe(createProjectId("/foo/baz"));
+  });
+
+  it("normalizes trailing-slash differences to the same value", () => {
+    expect(createProjectId("/foo")).toBe(createProjectId("/foo/"));
+  });
+});

--- a/src/lib/project-id.ts
+++ b/src/lib/project-id.ts
@@ -1,0 +1,16 @@
+import { createHash } from "node:crypto";
+import { resolve } from "node:path";
+
+/**
+ * Create a stable, short project identifier from an absolute path.
+ *
+ * The path is normalized with `path.resolve` so that trailing-slash and other
+ * representational differences yield the same identifier. The SHA-256 digest is
+ * truncated to the first 16 hex characters (64 bits), which is collision-free
+ * for practical purposes and avoids exposing the user's directory structure in
+ * the serialized initial state.
+ */
+export function createProjectId(absolutePath: string): string {
+  const normalized = resolve(absolutePath);
+  return createHash("sha256").update(normalized).digest("hex").slice(0, 16);
+}

--- a/src/server/routes/directory.tsx
+++ b/src/server/routes/directory.tsx
@@ -13,6 +13,7 @@ import type { FileTreeCache } from "../../lib/file-tree-cache.js";
 import { logger } from "../../lib/logger.js";
 import { renderMarkdown } from "../../lib/markdown.js";
 import { isNodeError } from "../../lib/node-error.js";
+import { createProjectId } from "../../lib/project-id.js";
 import { readTextFile } from "../../lib/read-text-file.js";
 import type { ResolvedStyles } from "../../lib/styles.js";
 import { Document, renderDocument } from "../renderer/document.js";
@@ -32,6 +33,7 @@ function findFirstFile(
 }
 
 function renderDirectoryView(params: {
+  readonly projectId: string;
   readonly dirTitle: string;
   readonly fileTitle: string;
   readonly currentPath: string;
@@ -40,14 +42,23 @@ function renderDirectoryView(params: {
   readonly tree: readonly FileTreeNode[];
   readonly styles: ResolvedStyles;
 }): string {
-  const { dirTitle, fileTitle, currentPath, contentType, html, tree, styles } =
-    params;
+  const {
+    projectId,
+    dirTitle,
+    fileTitle,
+    currentPath,
+    contentType,
+    html,
+    tree,
+    styles,
+  } = params;
   return renderDocument(
     <Document
       title={fileTitle}
       styles={styles}
       initialState={{
         mode: "directory",
+        projectId,
         dirTitle,
         currentPath,
         contentType,
@@ -109,6 +120,7 @@ export function createDirectoryRoutes(
   treeCache: FileTreeCache,
 ): Hono {
   const app = new Hono();
+  const projectId = createProjectId(dirPath);
 
   app.get("/", async (c) => {
     const treeResult = await treeCache.get();
@@ -136,6 +148,7 @@ export function createDirectoryRoutes(
     const dirTitle = basename(dirPath) || dirPath;
     return c.html(
       renderDirectoryView({
+        projectId,
         dirTitle,
         fileTitle: basename(firstFile.path),
         currentPath: firstFile.path,
@@ -177,6 +190,7 @@ export function createDirectoryRoutes(
     const dirTitle = basename(dirPath) || dirPath;
     return c.html(
       renderDirectoryView({
+        projectId,
         dirTitle,
         fileTitle: basename(relativePath),
         currentPath: relativePath,


### PR DESCRIPTION
## Summary
- ファイルツリーのディレクトリ開閉状態を localStorage に永続化し、リロード/再訪後も復元する
- サーバー側で `targetPath` の SHA-256 ハッシュ（先頭16hex）を `projectId` として生成し、`InitialState` 経由でクライアントへ渡して localStorage キーを名前空間化（同一 origin・同一ポートでの複数ディレクトリ衝突を防止）
- 各プロジェクトエントリに最終アクセス日時を持たせ、TTL（30日, 定数 `TTL_DAYS`）超過エントリをクライアント初期化時にパージ
- 開閉状態を `DirectoryItem` のローカル state から共有フック `useFileTreeState` に持ち上げ。デフォルトは全展開（collapsed=閉じているパス集合のみ保持）
- SSR/ハイドレーション整合は `use-sidebar` と同じ `useLayoutEffect` + 初期空集合パターンで担保

## Issue
Closes #89

## Implementation Plan
Based on `.issue/89/plan.md`（設計判断は `.issue/89/adr.md`）

## Test plan

### 動作確認方法
`pnpm dev:server` は `content.css?inline` を css loader が扱えず起動しないため（本 Issue とは無関係の既存問題）、本番ビルドで確認した:

\`\`\`bash
pnpm build
PORT=3000 node dist/index.mjs <確認用ディレクトリ>
\`\`\`

### 確認項目（`.issue/89/testing.md`）
- 開閉→リロードで復元される
- 別ディレクトリ起動で状態が混ざらない（projectId 名前空間化）
- 記録の無い/新規ディレクトリは展開で表示
- SSE ツリー更新後も開閉状態が維持される
- ハイドレーション不一致警告・ちらつきが無い
- localStorage 破損/無効でもクラッシュしない
- TTL 超過エントリがパージされる

### 自動テスト
- `src/lib/project-id.test.ts`, `src/client/lib/file-tree-state.test.ts` を追加
- `pnpm typecheck` / `pnpm lint` / `pnpm test`（235 件）すべて通過

## Browser Verification
- agent-browser で 7 テストケースを自動実行 → **全 PASS（FAIL 0）**
- TC-001 復元 / TC-002・002b 名前空間分離＆2 projectId 共存 / TC-003 SSR 整合 / TC-004 SSE 維持 / TC-EDGE-1 破損耐性 / TC-EDGE-2 TTL パージ
- ハイドレーション不一致警告なし、破損 JSON で全展開フォールバック＆自己修復を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)